### PR TITLE
feat: ship a Claude Code plugin manifest

### DIFF
--- a/.changeset/claude-plugin.md
+++ b/.changeset/claude-plugin.md
@@ -1,0 +1,7 @@
+---
+"@piotar/react-promise-bridge": minor
+---
+
+Ship a Claude Code plugin manifest (`.claude-plugin/plugin.json`) that exposes the bundled `SKILL.md`
+as a `react-promise-bridge` skill, so the package can be loaded directly from `node_modules` as a
+Claude Code plugin.

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
+    "name": "react-promise-bridge",
+    "version": "1.0.0",
+    "description": "Render a React component and await the value it produces as a Promise — for confirm dialogs, modals, popups, toasts, pickers, and any \"ask the user, get an answer back\" flow.",
+    "author": {
+        "name": "Piotr Tarasiuk"
+    },
+    "homepage": "https://github.com/piotar/react-promise-bridge",
+    "repository": "https://github.com/piotar/react-promise-bridge.git",
+    "license": "MIT",
+    "keywords": ["react", "promise", "dialog", "modal"],
+    "skills": ["./"]
+}

--- a/README.md
+++ b/README.md
@@ -297,6 +297,31 @@ A few behaviours are intentional but easy to trip over:
 | [#i02 React Bootstrap](/examples/i02_bootstrap/) | [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz_small.svg)](https://stackblitz.com/github/piotar/react-promise-bridge/tree/main/examples/i02_bootstrap?file=src/App.tsx) |
 | [#i03 Ant design (antd)](/examples/i03_antd/) | [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz_small.svg)](https://stackblitz.com/github/piotar/react-promise-bridge/tree/main/examples/i03_antd?file=src/App.tsx) |
 
+## AI agents
+
+A [`SKILL.md`](./SKILL.md) (agentskills.io format) ships with the package so the library can be taught
+to AI agents and installed via a skill manager.
+
+### Claude Code plugin
+
+The package doubles as a [Claude Code](https://docs.claude.com/en/docs/claude-code) plugin — a
+[`.claude-plugin/plugin.json`](./.claude-plugin/plugin.json) manifest exposes the bundled `SKILL.md`
+as a `react-promise-bridge` skill. Load it straight from `node_modules` (no separate install):
+
+```sh
+claude --plugin-dir node_modules/@piotar/react-promise-bridge     # per-session
+```
+
+To make the skill available globally instead, symlink the installed package into your skills directory
+— it then auto-loads in every session:
+
+```sh
+ln -s "$(npm root)/@piotar/react-promise-bridge" ~/.claude/skills/react-promise-bridge
+```
+
+Either way Claude gains a `react-promise-bridge` skill that knows when and how to bridge a React
+component to an awaitable promise.
+
 ## License
 
 [MIT](./LICENSE) © Piotr Tarasiuk

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "files": [
         "dist",
         "README.md",
-        "SKILL.md"
+        "SKILL.md",
+        ".claude-plugin"
     ],
     "main": "./dist/react-promise-bridge.umd.cjs",
     "module": "./dist/react-promise-bridge.js",


### PR DESCRIPTION
Mirrors pkg-sync's setup so `@piotar/react-promise-bridge` doubles as a [Claude Code](https://docs.claude.com/en/docs/claude-code) plugin.

## What
- **`.claude-plugin/plugin.json`** — manifest exposing the bundled `SKILL.md` as a `react-promise-bridge` skill (`skills: ["./"]`).
- **package.json** — add `.claude-plugin` to `files` so it ships in the npm tarball (verified via `npm pack --dry-run`: `632B .claude-plugin/plugin.json`).
- **README** — new "AI agents / Claude Code plugin" section documenting `claude --plugin-dir node_modules/@piotar/react-promise-bridge` and the global symlink.
- **changeset** (minor) so the change is released.

Users can then load it straight from `node_modules`:

```sh
claude --plugin-dir node_modules/@piotar/react-promise-bridge
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)